### PR TITLE
Update Cypress baseUrl and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google Analytics Ecommerce Demo site
-[![Netlify Status](https://api.netlify.com/api/v1/badges/7aeb5adf-a829-4176-8004-e2c1e391aaae/deploy-status)](https://app.netlify.com/sites/ga-ecomm-demo-test/deploys)
 
-### [Demo site](https://ga-ecomm-demo-test.netlify.app/)
+### [Demo site](https://ga-demo.dhdev.co/)
+
 ## What's up with this repo?
 
 It's just a sample HTML page with fake shop, made to trigger Universal Analytics and GA4 events for further testing. [Parcel](https://github.com/parcel-bundler/parcel) is used for serving and bundling files.
@@ -21,7 +21,7 @@ npm run build
 ```
 
 ## Deployment
-Deployment is done to Netlify automatically on every push to `main` branch.
+Deployment is done automatically on every push to `main` branch.
 
 ## Faking traffic
 You can generate fake traffic and sales to the site by running `npm run cy:run`. It will launch Cypress test, which visits production site multiple times with fake source / medium.

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'https://ga-ecomm-demo-test.netlify.app',
+    baseUrl: 'https://ga-demo.dhdev.co/',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'https://ga-demo.dhdev.co/',
+    baseUrl: 'https://ga-demo.dhdev.co',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ga-reporting-demo",
   "version": "1.0.0",
-  "description": "",
+  "description": "A fake website used for generating Google Analytics demo data",
   "source": "src/index.html",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "scripts": {
@@ -12,14 +12,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dutkiewicz/ga-reporting-demo.git"
+    "url": "git@github.com:dashhudson/google-analytics-demo-data.git"
   },
-  "author": "",
+  "author": "David Dutkiewicz <dawid@dashhudson.com>",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/dutkiewicz/ga-reporting-demo/issues"
+    "url": "https://github.com/dashhudson/google-analytics-demo-data/issues"
   },
-  "homepage": "https://github.com/dutkiewicz/ga-reporting-demo#readme",
+  "homepage": "https://github.com/dashhudson/google-analytics-demo-data#readme",
   "devDependencies": {
     "@parcel/transformer-sass": "^2.7.0",
     "cypress": "^10.10.0",


### PR DESCRIPTION
Since Yalcin moved deployed site to https://ga-demo.dhdev.co/, I changed Cypress' `baseUrl` and updated some docs.